### PR TITLE
Prevents writing an offset file after file closed

### DIFF
--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -215,6 +215,9 @@ class Pygtail(object):
         """
         Update the offset file with the current inode and offset.
         """
+        if self._is_closed():
+            logging.warn('Not writing to offset file, because fd is closed.')
+            return
         offset = self._filehandle().tell()
         inode = stat(self.filename).st_ino
         fh = open(self._offset_file, "w")


### PR DESCRIPTION
If the file is already closed, and _update_offset_file() gets called a
second time, it could re-open the file and seek just to write an
identical offset file. Therefore, we should not write an offset file
when self._is_closed() is true.