### PR TITLE
Adds posibility to set wait timeout to infinity

### DIFF
--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -284,7 +284,7 @@ class Pygtail(object):
             self._reload()
 
     def _wait_for_update(self):
-        while(self.time_waited < self.wait_timeout):
+        while(self.wait_timeout < 0 or self.time_waited < self.wait_timeout):
             time.sleep(self.wait_step)
             self.time_waited += self.wait_step
             line = self._filehandle().readline()


### PR DESCRIPTION
Previously pygtail would stop when nothing was added to the file it's
tailing after a certain amount of time (20s by default). We can now
set wait_timeout to a negative value to have pygtail never stop
waiting for data to be appended to the file it's tailing.